### PR TITLE
Fix javadoc and relocation POM publishing

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -90,7 +90,7 @@ dependencies {
     integrationTestImplementation("org.jetbrains.kotlinx:kotlin-jupyter-test-kit:0.12.0-181")
 }
 
-fun libraryPom() = Action<MavenPom> {
+val libraryPom = Action<MavenPom> {
     name.set("Develocity API Kotlin")
     description.set("A library to use the Develocity API in Kotlin")
     url.set(repoUrl)
@@ -121,18 +121,18 @@ publishing {
         create<MavenPublication>("develocityApiKotlin") {
             artifactId = "develocity-api-kotlin"
             from(components["java"])
-            pom(libraryPom())
+            pom(libraryPom)
         }
         // For occasional maven local publishing
         create<MavenPublication>("unsignedDevelocityApiKotlin") {
             artifactId = "develocity-api-kotlin"
             from(components["java"])
-            pom(libraryPom())
+            pom(libraryPom)
         }
         create<MavenPublication>("relocation") {
+            artifactId = "gradle-enterprise-api-kotlin"
             pom {
-                groupId = project.group.toString()
-                artifactId = "gradle-enterprise-api-kotlin"
+                libraryPom(this)
                 distributionManagement {
                     relocation {
                         groupId = project.group.toString()

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -27,7 +27,8 @@ java {
 }
 
 tasks.withType<DokkaTask>().configureEach {
-    dokkaSourceSets.all {
+    dokkaSourceSets.register("main") {
+        sourceRoot("src/main/kotlin")
         sourceLink {
             localDirectory.set(file("src/main/kotlin"))
             remoteUrl.set(URL("$repoUrl/blob/$version/src/main/kotlin"))

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -164,7 +164,10 @@ publishing {
 fun isCI() = System.getenv("CI").toBoolean()
 
 signing {
-    sign(publishing.publications["develocityApiKotlin"])
+    sign(
+        publishing.publications["develocityApiKotlin"],
+        publishing.publications["relocation"],
+    )
     if (isCI()) {
         useInMemoryPgpKeys(
             project.properties["signing.secretKey"] as String?,


### PR DESCRIPTION
Fix dokka source root. Javadoc generation [started failing](https://github.com/gabrielfeo/develocity-api-kotlin/actions/runs/8576587721) after plugin refactoring. Some ordering change (probably) caused Dokka to no longer detect the source root and just output "Nothing to document".

Add repo, developer info to relocation POM (#184) and sign it. Relocation POM failed publishing of 2024.1.0 due to failing these checks.