### PR TITLE
Update usage of Develocity plugin, wrapper-validation

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -22,11 +22,10 @@ runs:
       with:
         distribution: zulu
         java-version: 21
-    - name: Validate Gradle wrapper JAR
-      uses: gradle/actions/wrapper-validation@v3
     - name: Set up Gradle
       uses: gradle/actions/setup-gradle@v3
       with:
+        validate-wrappers: true
         add-job-summary-as-pr-comment: 'on-failure'
     - name: Run Gradle
       shell: bash

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,7 +3,7 @@ pluginManagement {
 }
 
 plugins {
-    id("com.gradle.enterprise") version("3.17.2")
+    id("com.gradle.develocity") version("3.17.2")
     id("org.gradle.toolchains.foojay-resolver-convention") version("0.8.0")
 }
 
@@ -19,10 +19,9 @@ dependencyResolutionManagement {
     }
 }
 
-gradleEnterprise {
+develocity {
     buildScan {
-        publishAlways()
-        termsOfServiceUrl = "https://gradle.com/terms-of-service"
-        termsOfServiceAgree = "yes"
+        termsOfUseUrl = "https://gradle.com/help/legal-terms-of-use"
+        termsOfUseAgree = "yes"
     }
 }


### PR DESCRIPTION
Plugin artifact after 3.17 has new name and API. Wrapper validation now built into the setup-gradle action.