### PR TITLE
Run :build-logic tests in CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,7 +17,10 @@ jobs:
       - name: gradle test
         uses: ./.github/actions/build
         with:
-          args: 'check -x :library:integrationTest'
+          args: >-
+            test
+            compileIntegrationTestKotlin
+            :build-logic:check
 
   python-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,9 +17,7 @@ jobs:
       - name: gradle test
         uses: ./.github/actions/build
         with:
-          args: 'test compileIntegrationTestKotlin'
-          # artifact-name: 'Test reports (${{matrix.runner}})'
-          # path-to-upload: '**/build/reports/tests/**'
+          args: 'check -x :library:integrationTest'
 
   python-tests:
     runs-on: ubuntu-latest

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -16,6 +16,10 @@ gradlePlugin {
     testSourceSets(sourceSets["functionalTest"])
 }
 
+tasks.named("check") {
+    dependsOn(tasks.withType<Test>())
+}
+
 dependencies {
     implementation(libs.kotlin.plugin)
     implementation(libs.dokka.plugin)

--- a/build-logic/src/functionalTest/kotlin/com/gabrielfeo/task/PostProcessGeneratedApiTest.kt
+++ b/build-logic/src/functionalTest/kotlin/com/gabrielfeo/task/PostProcessGeneratedApiTest.kt
@@ -24,7 +24,7 @@ class PostProcessGeneratedApiTest {
      */
     @Test
     fun apiInterfacePostProcessing() = testPostProcessing(
-        inputPath = "com/gabrielfeo/develocity/api/BuildsApi.kt",
+        inputPath = "src/main/kotlin/com/gabrielfeo/develocity/api/BuildsApi.kt",
         inputContent = """
             package com.gabrielfeo.develocity.api
 
@@ -67,7 +67,7 @@ class PostProcessGeneratedApiTest {
                 @GET("api/builds/{id}")
                 suspend fun getBuild(@Path("id") id: kotlin.String, @Query("models") models: kotlin.collections.List<BuildModelName>? = null, @Query("availabilityWaitTimeoutSecs") availabilityWaitTimeoutSecs: kotlin.Int? = null): Response<Build>
         """.trimIndent(),
-        outputPath = "com/gabrielfeo/develocity/api/BuildsApi.kt",
+        outputPath = "src/main/kotlin/com/gabrielfeo/develocity/api/BuildsApi.kt",
         outputContent = """
             package com.gabrielfeo.develocity.api
 
@@ -106,7 +106,7 @@ class PostProcessGeneratedApiTest {
      */
     @Test
     fun buildModelNameEnumPostProcessing() = testPostProcessing(
-        inputPath = "com/gabrielfeo/develocity/api/model/BuildModelName.kt",
+        inputPath = "src/main/kotlin/com/gabrielfeo/develocity/api/model/BuildModelName.kt",
         inputContent = """
             @JsonClass(generateAdapter = false)
             enum class BuildModelName(val value: kotlin.String) {
@@ -117,7 +117,7 @@ class PostProcessGeneratedApiTest {
                 @Json(name = "gradle-build-cache-performance")
                 gradleMinusBuildMinusCacheMinusPerformance("gradle-build-cache-performance"),
         """.trimIndent(),
-        outputPath = "com/gabrielfeo/develocity/api/model/BuildModelName.kt",
+        outputPath = "src/main/kotlin/com/gabrielfeo/develocity/api/model/BuildModelName.kt",
         outputContent = """
             @JsonClass(generateAdapter = false)
             enum class BuildModelName(val value: kotlin.String) {
@@ -153,6 +153,7 @@ class PostProcessGeneratedApiTest {
             .withProjectDir(projectDir)
             .withPluginClasspath()
             .withArguments(args)
+            .forwardOutput()
             .build()
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,3 @@
+tasks.register("check") {
+  dependsOn(gradle.includedBuilds.map { it.task(":check") })
+}


### PR DESCRIPTION
Also fix the tests and wire the `check` tasks together. 

The complete `check` is still not run run in CI because `integrationTest` and `:examples:check` require credentials to a Develocity instance. I don't have credentials that I'm allowed to use on GitHub (even as secrets).