### PR TITLE
Shorten Renovate PR descriptions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,4 +11,5 @@
   "prConcurrentLimit": 0,
   "prHourlyLimit": 0,
   "rebaseWhen": "behind-base-branch",
+  "prBodyTemplate": "{{{header}}}{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}{{{controls}}}{{{footer}}}"
 }


### PR DESCRIPTION
Remove `configDescription` (present in default value) from PR body.