### PR TITLE
Split versions of Kotlin/Jupyter artifacts

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -17,7 +17,7 @@
     // Add a changelog link to Develocity plugin PRs
     {
       "matchDepNames": ["com.gradle.develocity"],
-      "prBodyNotes": "https://docs.gradle.com/develocity/gradle-plugin/current#release_history"
+      "prBodyNotes": ["https://docs.gradle.com/develocity/gradle-plugin/current#release_history"],
     },
     // Group Kotlin/Jupyter artifact bumps
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -16,12 +16,12 @@
   "packageRules": [
     // Add a changelog link to Develocity plugin PRs
     {
-      "matchPackageNames": ["com.gradle.develocity"],
+      "matchDepNames": ["com.gradle.develocity"],
       "prBodyNotes": "https://docs.gradle.com/develocity/gradle-plugin/current#release_history"
     },
     // Group Kotlin/Jupyter artifact bumps
     {
-      "matchPackageNames": [
+      "matchDepNames": [
         "kotlin-jupyter-test-kit",
         "kotlin-jupyter-api",
         "org.jetbrains.kotlin.jupyter.api",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,9 +14,21 @@
   // Remove configDescription from PR body
   "prBodyTemplate": "{{{header}}}{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}{{{controls}}}{{{footer}}}",
   "packageRules": [
+    // Add a changelog link to Develocity plugin PRs
     {
       "matchPackageNames": ["com.gradle.develocity"],
       "prBodyNotes": "https://docs.gradle.com/develocity/gradle-plugin/current#release_history"
+    },
+    // Group Kotlin/Jupyter artifact bumps
+    {
+      "matchPackageNames": [
+        "kotlin-jupyter-test-kit",
+        "kotlin-jupyter-api",
+        "org.jetbrains.kotlin.jupyter.api",
+        "kotlin-jupyter-api-gradle-plugin",
+      ],
+      "groupName": "Kotlin/Jupyter",
+      "groupSlug": "kotlin-jupyter",
     },
   ],
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,4 +7,7 @@ org.gradle.jvmargs=-Xmx5g
 org.gradle.caching=true
 # Becomes default in Gradle 9.0
 org.gradle.kotlin.dsl.skipMetadataVersionCheck=false
+# Explicitly added at different versions, due to Kotlin/kotlin-jupyter#462
+kotlin.jupyter.add.api=false
+kotlin.jupyter.add.scanner=false
 kotlin.jupyter.add.testkit=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,9 @@
 kotlin = "2.0.0"
 dokka = "1.9.20"
 openapi-generator = "7.7.0"
-jupyter = "0.12.0-236"
+jupyter-api = "0.12.0-236"
+jupyter-testkit = "0.12.0-236"
+jupyter-plugin = "0.12.0-236"
 okio = "3.9.0"
 moshi = "1.15.1"
 okhttp = "4.12.0"
@@ -23,7 +25,8 @@ retrofit-converter-moshi = { module = "com.squareup.retrofit2:converter-moshi", 
 retrofit-converter-scalars = { module = "com.squareup.retrofit2:converter-scalars", version.ref = "retrofit" }
 kotlin-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlin-coroutines" }
 kotlin-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlin-coroutines" }
-kotlin-jupyter-testkit = { module = "org.jetbrains.kotlinx:kotlin-jupyter-test-kit", version.ref = "jupyter" }
+kotlin-jupyter-api = { module = "org.jetbrains.kotlinx:kotlin-jupyter-api", version.ref = "jupyter-api" }
+kotlin-jupyter-testkit = { module = "org.jetbrains.kotlinx:kotlin-jupyter-test-kit", version.ref = "jupyter-testkit" }
 kotlin-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 dokka-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
 openapi-generator-plugin = { module = "org.openapitools:openapi-generator-gradle-plugin", version.ref = "openapi-generator" }
@@ -32,4 +35,4 @@ slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
 
 [plugins]
-kotlin-jupyter = { id = "org.jetbrains.kotlin.jupyter.api", version.ref = "jupyter" }
+kotlin-jupyter = { id = "org.jetbrains.kotlin.jupyter.api", version.ref = "jupyter-plugin" }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
     api(libs.kotlin.coroutines)
     implementation(libs.slf4j.api)
     runtimeOnly(libs.slf4j.simple)
+    compileOnly(libs.kotlin.jupyter.api)
     testImplementation(libs.okhttp.mockwebserver)
     testImplementation(libs.okio)
     testImplementation(libs.kotlin.coroutines.test)


### PR DESCRIPTION
Prevent the Kotlin Jupyter plugin from adding the artifacts automatically, as it adds non-existent
versions by default (Kotlin/kotlin-jupyter#462).

- https://plugins.gradle.org/plugin/org.jetbrains.kotlin.jupyter.api
- https://central.sonatype.com/artifact/org.jetbrains.kotlinx/kotlin-jupyter-api
- https://central.sonatype.com/artifact/org.jetbrains.kotlinx/kotlin-jupyter-test-kit

Set Renovate to group bumps of the artifacts in a single PR when possible. Also update config to pass [Renovate config validation][1]:

1. `matchPackageNames` -> `matchDepNames`
2. `prBodyNotes` as array

---

>matchPackageNames will try matching packageName first and then fall back to matching depName. If the fallback is used, Renovate will log a warning, because the fallback will be removed in a future release. Use matchDepNames instead.

```
DEBUG: validateReconfigureBranch()
DEBUG: Setting current branch to renovate/reconfigure
DEBUG: latest commit
{
  "branchName": "renovate/reconfigure"
  "latestCommitDate": "2024-07-23T16:56:47+01:00"
}

DEBUG: Validation Errors
{
  "errors": "Configuration option `packageRules[0].prBodyNotes` should be a list (Array)"
}
```

[1]: https://developer.mend.io/github/gabrielfeo/develocity-api-kotlin/-/job/df3f3a0c-ae75-46e1-b215-6675b0281030