### PR TITLE
Declare pip requirements of example-notebooks

### DIFF
--- a/examples/example-notebooks/requirements.txt
+++ b/examples/example-notebooks/requirements.txt
@@ -1,0 +1,2 @@
+jupyterlab==4.2.4
+kotlin-jupyter-kernel==0.12.0.217


### PR DESCRIPTION
Ensures example notebooks are tested in a reproducible environment. Also encourages re-testing them when new kernel versions are released, since Renovate will open PRs to update `requirements.txt`.

Check build: https://scans.gradle.com/s/dt7s2rme6uylc