### PR TITLE
Fix Config.logLevel precedence and javadoc

### DIFF
--- a/library/src/main/kotlin/com/gabrielfeo/develocity/api/internal/LoggerFactory.kt
+++ b/library/src/main/kotlin/com/gabrielfeo/develocity/api/internal/LoggerFactory.kt
@@ -18,11 +18,10 @@ class RealLoggerFactory(
     }
 
     private fun setLogLevel() {
-        if (System.getProperty(SIMPLE_LOGGER_LOG_LEVEL) != null) {
-            return
-        }
         System.setProperty(SIMPLE_LOGGER_LOG_LEVEL, config.logLevel)
     }
-}
 
-internal const val SIMPLE_LOGGER_LOG_LEVEL = "org.slf4j.simpleLogger.defaultLogLevel"
+    companion object {
+        const val LOG_LEVEL_SYSTEM_PROPERTY = "org.slf4j.simpleLogger.defaultLogLevel"
+    }
+}

--- a/library/src/main/kotlin/com/gabrielfeo/develocity/api/internal/SystemProperties.kt
+++ b/library/src/main/kotlin/com/gabrielfeo/develocity/api/internal/SystemProperties.kt
@@ -3,9 +3,11 @@ package com.gabrielfeo.develocity.api.internal
 internal var systemProperties: SystemProperties = RealSystemProperties
 
 internal interface SystemProperties {
-    operator fun get(name: String): String?
+    val userHome: String?
+    val logLevel: String?
 }
 
 internal object RealSystemProperties : SystemProperties {
-    override fun get(name: String): String? = System.getProperty(name)
+    override val userHome: String? = System.getProperty("user.home")
+    override val logLevel: String? = System.getProperty(RealLoggerFactory.LOG_LEVEL_SYSTEM_PROPERTY)
 }


### PR DESCRIPTION
Fix precedence of `Config.logLevel` sources so that environment variable is always preferred. Also fixes #284.