### PR TITLE
Fix Dokka source links

### DIFF
--- a/build-logic/src/main/kotlin/com/gabrielfeo/kotlin-jvm-library.gradle.kts
+++ b/build-logic/src/main/kotlin/com/gabrielfeo/kotlin-jvm-library.gradle.kts
@@ -21,12 +21,13 @@ java {
     }
 }
 
+val kotlinSourceRoot = file("src/main/kotlin")
 tasks.withType<DokkaTask>().configureEach {
     dokkaSourceSets.all {
-        sourceRoot("src/main/kotlin")
+        sourceRoot(kotlinSourceRoot)
         sourceLink {
-            localDirectory.set(file("src/main/kotlin"))
-            remoteUrl.set(repoUrl.map { URL("$it/blob/$version/src/main/kotlin") })
+            localDirectory.set(kotlinSourceRoot)
+            remoteUrl.set(repoUrl.map { URL("$it/blob/$version/${kotlinSourceRoot.relativeTo(rootDir)}") })
             remoteLineSuffix.set("#L")
         }
         jdkVersion.set(11)

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -1,8 +1,6 @@
 @file:Suppress("UnstableApiUsage")
 
 import java.net.URL
-import org.jetbrains.dokka.DokkaConfiguration.Visibility.PUBLIC
-import org.jetbrains.dokka.gradle.DokkaTask
 
 plugins {
     id("com.gabrielfeo.kotlin-jvm-library")


### PR DESCRIPTION
Fix #283

>"source" links in documentation are 404.
>
>- Example case: [Config.logLevel](https://gabrielfeo.github.io/develocity-api-kotlin/library/com.gabrielfeo.develocity.api/-config/log-level.html?query=val%20logLevel:%20String)
>- Expected URL: https://github.com/gabrielfeo/develocity-api-kotlin/blob/2024.2.0-alpha01/library/src/main/kotlin/com/gabrielfeo/develocity/api/Config.kt#L31
>- Actual URL: https://github.com/gabrielfeo/develocity-api-kotlin/blob/2024.2.0-alpha01/src/main/kotlin/com/gabrielfeo/develocity/api/Config.kt#L31