### PR TITLE
Fix GradleConfigurationCacheResult.Outcome enum naming

### DIFF
--- a/build-logic/src/functionalTest/kotlin/com/gabrielfeo/task/PostProcessGeneratedApiTest.kt
+++ b/build-logic/src/functionalTest/kotlin/com/gabrielfeo/task/PostProcessGeneratedApiTest.kt
@@ -146,6 +146,43 @@ class PostProcessGeneratedApiTest {
         """.trimIndent(),
     )
 
+    /**
+     * Fixes enum case names: hIT -> hit (gabrielfeo/develocity-api-kotlin#282).
+     *
+     * Occurs when API spec enum name is uppercase and generator enumPropertyNaming is camelCase.
+     */
+    @Test
+    fun gradleConfigurationCacheResultOutcomeEnumPostProcessing() = testPostProcessing(
+        inputPath = "src/main/kotlin/com/gabrielfeo/develocity/api/model/GradleConfigurationCacheResult.kt",
+        inputContent = """
+            /**
+             * The outcome of the configuration cache operation:   * `HIT` - There was a configuration cache hit.   * `MISS` - There was a configuration cache miss.   * `FAILED` - There was a configuration cache related failure.
+             *
+             * Values: hIT,mISS,fAILED
+             */
+            @JsonClass(generateAdapter = false)
+            enum class Outcome(val value: kotlin.String) {
+                @Json(name = "HIT") hIT("HIT"),
+                @Json(name = "MISS") mISS("MISS"),
+                @Json(name = "FAILED") fAILED("FAILED");
+            }
+        """.trimIndent(),
+        outputPath = "src/main/kotlin/com/gabrielfeo/develocity/api/model/GradleConfigurationCacheResult.kt",
+        outputContent = """
+            /**
+             * The outcome of the configuration cache operation:   * `HIT` - There was a configuration cache hit.   * `MISS` - There was a configuration cache miss.   * `FAILED` - There was a configuration cache related failure.
+             *
+             * Values: hit,miss,failed
+             */
+            @JsonClass(generateAdapter = false)
+            enum class Outcome(val value: kotlin.String) {
+                @Json(name = "HIT") hit("HIT"),
+                @Json(name = "MISS") miss("MISS"),
+                @Json(name = "FAILED") failed("FAILED");
+            }
+        """.trimIndent(),
+    )
+
     private fun testPostProcessing(
         inputPath: String,
         inputContent: String,

--- a/build-logic/src/main/kotlin/com/gabrielfeo/develocity-api-code-generation.gradle.kts
+++ b/build-logic/src/main/kotlin/com/gabrielfeo/develocity-api-code-generation.gradle.kts
@@ -51,6 +51,7 @@ openApiGenerate {
     invokerPackage.set("com.gabrielfeo.develocity.api.internal")
     additionalProperties.put("library", "jvm-retrofit2")
     additionalProperties.put("useCoroutines", true)
+    additionalProperties.put("enumPropertyNaming", "camelCase")
     cleanupOutput.set(true)
 }
 

--- a/build-logic/src/main/kotlin/com/gabrielfeo/develocity-api-code-generation.gradle.kts
+++ b/build-logic/src/main/kotlin/com/gabrielfeo/develocity-api-code-generation.gradle.kts
@@ -51,7 +51,6 @@ openApiGenerate {
     invokerPackage.set("com.gabrielfeo.develocity.api.internal")
     additionalProperties.put("library", "jvm-retrofit2")
     additionalProperties.put("useCoroutines", true)
-    additionalProperties.put("enumPropertyNaming", "camelCase")
     cleanupOutput.set(true)
 }
 

--- a/build-logic/src/main/kotlin/com/gabrielfeo/task/PostProcessGeneratedApi.kt
+++ b/build-logic/src/main/kotlin/com/gabrielfeo/task/PostProcessGeneratedApi.kt
@@ -80,5 +80,30 @@ abstract class PostProcessGeneratedApi @Inject constructor(
                 )
             }
         }
+        // Fix mapping of GradleConfigurationCacheResult.Outcome: hIT -> hit
+        val file = "com/gabrielfeo/develocity/api/model/GradleConfigurationCacheResult.kt"
+        replaceAll("hIT", "hit", dir = srcDir, includes = file)
+        replaceAll("mISS", "miss", dir = srcDir, includes = file)
+        replaceAll("fAILED", "failed", dir = srcDir, includes = file)
+    }
+
+    private fun replaceAll(
+        match: String,
+        replace: String,
+        dir: File,
+        includes: String,
+    ) {
+        ant.withGroovyBuilder {
+            "replaceregexp"(
+                "match" to match,
+                "replace" to replace,
+                "flags" to "mg",
+            ) {
+                "fileset"(
+                    "dir" to dir,
+                    "includes" to includes,
+                )
+            }
+        }
     }
 }


### PR DESCRIPTION
Fix #282 with generated API post-processing.

>Enum members name casing goes against the Kotlin style guide and will pollute client code. Class is only present after library v2024.2.0-alpha01.
>
>```kotlin
>    /**
>     * The outcome of the configuration cache operation:   * `HIT` - There was a configuration cache hit.   * `MISS` - There was a configuration cache miss.   * `FAILED` - There was a configuration cache related failure. 
>     *
>     * Values: hIT,mISS,fAILED
>     */
>    @JsonClass(generateAdapter = false)
>    enum class Outcome(val value: kotlin.String) {
>        @Json(name = "HIT") hIT("HIT"),
>        @Json(name = "MISS") mISS("MISS"),
>        @Json(name = "FAILED") fAILED("FAILED");
>    }
>```
>
>Occurs when the API spec's `enum` items are upper-case and the Kotlin generator's `enumPropertyNaming` is set to `camelCase`.
>
>```yaml
>    GradleConfigurationCacheResult:
>      type: object
>      description: The configuration cache result of a Gradle build.
>      required:
>        - outcome
>      properties:
>        outcome:
>          type: string
>          enum:
>            - HIT
>            - MISS
>            - FAILED
>          description: |
>            The outcome of the configuration cache operation:
>              * `HIT` - There was a configuration cache hit.
>              * `MISS` - There was a configuration cache miss.
>              * `FAILED` - There was a configuration cache related failure.
>```
>
>The enum casing found in the new spec is inconsistent with previous enums, like `TestOutcome`:
>
>```yaml
>    TestOutcome:
>      type: string
>      enum:
>        - passed
>        - failed
>        - skipped
>        - flaky
>        - notSelected
>```
>
>The issue is surfaced due to the spec's inconsistency, but the cause is OpenAPI Generator's `enumPropertyNaming` implementation. The actual [`enumPropertyNaming` options](https://github.com/OpenAPITools/openapi-generator/blob/master/docs/generators/kotlin.md) implementation will only convert the first char in some cases (see [`CamelizeOptions`](https://github.com/OpenAPITools/openapi-generator/blob/2bc0e5f7457615f175ba936a0093f8fc5f7ff1d2/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/CamelizeOption.java))