### PR TITLE
Fix replace_string badge replacements

### DIFF
--- a/.github/scripts/replace_string.py
+++ b/.github/scripts/replace_string.py
@@ -37,7 +37,7 @@ def replace_string(path: Path, old: str, new: str) -> None:
 def _replace_badge_versions(text: str, old: str, new: str) -> str:
     return re.sub(
         rf'''https://img\.shields\.io/badge/(.+?)-{_badge_version(old)}-(\w+)''',
-        f'''https://img.shields.io/badge/\1-{_badge_version(new)}-\3''',
+        rf'''https://img.shields.io/badge/\1-{_badge_version(new)}-\2''',
         text
     )
 

--- a/.github/scripts/test_replace_string.py
+++ b/.github/scripts/test_replace_string.py
@@ -64,7 +64,7 @@ class TestReplaceString(unittest.TestCase):
         self.assertNotIn(old, content)
 
     def _assert_badge_versions_replaced(self, content, old, new):
-        if "badge/Maven%20Central-" not in content:
+        if "badge/" not in content:
             return
         self.assertIn(
             f"badge/Maven%20Central-{new.replace('-', '--')}-blue", content)


### PR DESCRIPTION
Fix version replacement in badge URLs. Noticed in #295:
 
```diff
-[![Maven Central](https://img.shields.io/badge/Maven%20Central-2024.2.0--alpha01-blue)][14]
-[![Javadoc](https://img.shields.io/badge/Javadoc-2024.2.0--alpha01-orange)][7]
+[![Maven Central](https://img.shields.io/badge/-2024.2.0--alpha02-)][14]
+[![Javadoc](https://img.shields.io/badge/-2024.2.0--alpha02-)][7]
```