### PR TITLE
Bump library version in examples to 2024.2.0-alpha02 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Develocity API Kotlin
 
-[![Maven Central](https://img.shields.io/badge/Maven%20Central-2024.2.0--alpha01-blue)][14]
-[![Javadoc](https://img.shields.io/badge/Javadoc-2024.2.0--alpha01-orange)][7]
+[![Maven Central](https://img.shields.io/badge/Maven%20Central-2024.2.0--alpha02-blue)][14]
+[![Javadoc](https://img.shields.io/badge/Javadoc-2024.2.0--alpha02-orange)][7]
 
 (formerly `gradle-enterprise-api-kotlin`)
 
@@ -36,7 +36,7 @@ Set up environment variables and use the library from any notebook, script or pr
 
 ```
 %useLatestDescriptors
-%use develocity-api-kotlin(version=2024.2.0-alpha01)
+%use develocity-api-kotlin(version=2024.2.0-alpha02)
 ```
 
 </details>
@@ -45,7 +45,7 @@ Set up environment variables and use the library from any notebook, script or pr
   <summary>Add to a Kotlin script</summary>
 
 ```kotlin
-@file:DependsOn("com.gabrielfeo:develocity-api-kotlin:2024.2.0-alpha01")
+@file:DependsOn("com.gabrielfeo:develocity-api-kotlin:2024.2.0-alpha02")
 ```
 
 </details>
@@ -55,7 +55,7 @@ Set up environment variables and use the library from any notebook, script or pr
 
 ```kotlin
 dependencies {
-  implementation("com.gabrielfeo:develocity-api-kotlin:2024.2.0-alpha01")
+  implementation("com.gabrielfeo:develocity-api-kotlin:2024.2.0-alpha02")
 }
 ```
 
@@ -200,7 +200,7 @@ import com.gabrielfeo.develocity.api.model.extension.*
 [11]: https://gabrielfeo.github.io/develocity-api-kotlin/library/com.gabrielfeo.develocity.api/-develocity-api/shutdown.html
 [12]: https://gabrielfeo.github.io/develocity-api-kotlin/library/com.gabrielfeo.develocity.api/-config/-cache-config/cache-enabled.html
 [13]: https://gabrielfeo.github.io/develocity-api-kotlin/library/com.gabrielfeo.develocity.api/-config/-cache-config/index.html
-[14]: https://central.sonatype.com/artifact/com.gabrielfeo/develocity-api-kotlin/2024.2.0-alpha01
+[14]: https://central.sonatype.com/artifact/com.gabrielfeo/develocity-api-kotlin/2024.2.0-alpha02
 [16]: https://gabrielfeo.github.io/develocity-api-kotlin/library/com.gabrielfeo.develocity.api/-config/api-url.html
 [17]: https://gabrielfeo.github.io/develocity-api-kotlin/library/com.gabrielfeo.develocity.api/-config/api-token.html
 [18]: https://gabrielfeo.github.io/develocity-api-kotlin/library/com.gabrielfeo.develocity.api/-builds-api/index.html

--- a/examples/example-notebooks/MostFrequentBuilds.ipynb
+++ b/examples/example-notebooks/MostFrequentBuilds.ipynb
@@ -35,7 +35,7 @@
     "Add libraries to use, via line magics. `%use` is a [line magic](https://github.com/Kotlin/kotlin-jupyter#line-magics) of the Kotlin kernel that can do much more than adding the library. To illustrate, this setup can be replaced with a single line magic.\n",
     "\n",
     "```kotlin\n",
-    "@file:DependsOn(\"com.gabrielfeo:develocity-api-kotlin:2024.2.0-alpha01\")\n",
+    "@file:DependsOn(\"com.gabrielfeo:develocity-api-kotlin:2024.2.0-alpha02\")\n",
     "\n",
     "import com.gabrielfeo.develocity.api.*\n",
     "import com.gabrielfeo.develocity.api.model.*\n",
@@ -45,7 +45,7 @@
     "is the same as:\n",
     "\n",
     "```\n",
-    "%use develocity-api-kotlin(version=2024.2.0-alpha01)\n",
+    "%use develocity-api-kotlin(version=2024.2.0-alpha02)\n",
     "```"
    ]
   },
@@ -62,7 +62,7 @@
    "outputs": [],
    "source": [
     "%useLatestDescriptors\n",
-    "%use develocity-api-kotlin(version=2024.2.0-alpha01)\n",
+    "%use develocity-api-kotlin(version=2024.2.0-alpha02)\n",
     "%use coroutines(v=1.7.1)\n",
     "\n",
     "val api = DevelocityApi.newInstance()"

--- a/examples/example-project/build.gradle.kts
+++ b/examples/example-project/build.gradle.kts
@@ -15,5 +15,5 @@ java {
 }
 
 dependencies {
-    implementation("com.gabrielfeo:develocity-api-kotlin:2024.2.0-alpha01")
+    implementation("com.gabrielfeo:develocity-api-kotlin:2024.2.0-alpha02")
 }

--- a/examples/example-scripts/example-script.main.kts
+++ b/examples/example-scripts/example-script.main.kts
@@ -17,7 +17,7 @@
  * Run this with at least 1GB of heap to accomodate the fetched data: JAVA_OPTS=-Xmx1g
  */
 
-@file:DependsOn("com.gabrielfeo:develocity-api-kotlin:2024.2.0-alpha01")
+@file:DependsOn("com.gabrielfeo:develocity-api-kotlin:2024.2.0-alpha02")
 
 import com.gabrielfeo.develocity.api.*
 import com.gabrielfeo.develocity.api.model.*


### PR DESCRIPTION
Ran `:examples:check` against a 2024.1.1 Develocity instance: https://scans.gradle.com/s/fbmbx3af5mjmu