### PR TITLE
Address Kotlin Gradle Plugin warning

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    id("com.gabrielfeo.kotlin-jvm-library") apply false
+}
+
 tasks.register("check") {
-  dependsOn(gradle.includedBuilds.map { it.task(":check") })
+    dependsOn(gradle.includedBuilds.map { it.task(":check") })
 }


### PR DESCRIPTION
Migrate from an unsupported usage of Kotlin Gradle Plugin, noted from a build warning:

```
The Kotlin Gradle plugin was loaded multiple times in different subprojects, which is not supported and may break the build. 
This might happen in subprojects that apply the Kotlin plugins with the Gradle 'plugins { ... }' DSL if they specify explicit versions, even if the versions are equal.
Please add the Kotlin plugin to the common parent project or the root project, then remove the versions in the subprojects.
If the parent project does not need the plugin, add 'apply false' to the plugin line.
See: https://docs.gradle.org/current/userguide/plugins.html#sec:subprojects_plugins_dsl
The Kotlin plugin was loaded in the following projects: ':library', ':examples:example-project'
```