### PR TITLE
Refactor build logic

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -6,8 +6,8 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
-        vendor.set(JvmVendorSpec.AZUL)
+        languageVersion = JavaLanguageVersion.of(11)
+        vendor = JvmVendorSpec.AZUL
     }
 }
 

--- a/build-logic/src/main/kotlin/com/gabrielfeo/develocity-api-code-generation.gradle.kts
+++ b/build-logic/src/main/kotlin/com/gabrielfeo/develocity-api-code-generation.gradle.kts
@@ -34,25 +34,25 @@ val downloadApiSpec by tasks.registering {
 }
 
 openApiGenerate {
-    generatorName.set("kotlin")
+    generatorName = "kotlin"
     val spec = when {
         localSpecPath.isPresent() -> localSpecPath.map { rootProject.file(it).absolutePath }
         else -> downloadApiSpec.map { it.outputs.files.first().absolutePath }
     }
-    inputSpec.set(spec)
+    inputSpec = spec
     val generateDir = project.layout.buildDirectory.dir("generated-api")
         .map { it.asFile.absolutePath }
-    outputDir.set(generateDir)
+    outputDir = generateDir
     val ignoreFile = project.layout.projectDirectory.file(".openapi-generator-ignore")
-    ignoreFileOverride.set(ignoreFile.asFile.absolutePath)
-    apiPackage.set("com.gabrielfeo.develocity.api")
-    modelPackage.set("com.gabrielfeo.develocity.api.model")
-    packageName.set("com.gabrielfeo.develocity.api.internal")
-    invokerPackage.set("com.gabrielfeo.develocity.api.internal")
+    ignoreFileOverride = ignoreFile.asFile.absolutePath
+    apiPackage = "com.gabrielfeo.develocity.api"
+    modelPackage = "com.gabrielfeo.develocity.api.model"
+    packageName = "com.gabrielfeo.develocity.api.internal"
+    invokerPackage = "com.gabrielfeo.develocity.api.internal"
     additionalProperties.put("library", "jvm-retrofit2")
     additionalProperties.put("useCoroutines", true)
     additionalProperties.put("enumPropertyNaming", "camelCase")
-    cleanupOutput.set(true)
+    cleanupOutput = true
 }
 
 val postProcessGeneratedApi by tasks.registering(PostProcessGeneratedApi::class) {

--- a/build-logic/src/main/kotlin/com/gabrielfeo/kotlin-jvm-library.gradle.kts
+++ b/build-logic/src/main/kotlin/com/gabrielfeo/kotlin-jvm-library.gradle.kts
@@ -7,7 +7,6 @@ import java.net.URL
 plugins {
     id("org.jetbrains.kotlin.jvm")
     id("org.jetbrains.dokka")
-    id("org.jetbrains.kotlinx.binary-compatibility-validator")
     `java-library`
 }
 

--- a/build-logic/src/main/kotlin/com/gabrielfeo/kotlin-jvm-library.gradle.kts
+++ b/build-logic/src/main/kotlin/com/gabrielfeo/kotlin-jvm-library.gradle.kts
@@ -1,20 +1,11 @@
 package com.gabrielfeo
 
-import org.jetbrains.dokka.DokkaConfiguration.Visibility.PUBLIC
-import org.jetbrains.dokka.gradle.DokkaTask
-import java.net.URL
-
 plugins {
     id("org.jetbrains.kotlin.jvm")
-    id("org.jetbrains.dokka")
     `java-library`
 }
 
-val repoUrl: Provider<String> = providers.gradleProperty("repo.url")
-
 java {
-    withSourcesJar()
-    withJavadocJar()
     toolchain {
         languageVersion = JavaLanguageVersion.of(11)
         vendor = JvmVendorSpec.AZUL
@@ -22,32 +13,4 @@ java {
     consistentResolution {
         useRuntimeClasspathVersions()
     }
-}
-
-val kotlinSourceRoot = file("src/main/kotlin")
-tasks.withType<DokkaTask>().configureEach {
-    dokkaSourceSets.all {
-        sourceRoot(kotlinSourceRoot)
-        sourceLink {
-            localDirectory = kotlinSourceRoot
-            remoteUrl = repoUrl.map { URL("$it/blob/$version/${kotlinSourceRoot.relativeTo(rootDir)}") }
-            remoteLineSuffix = "#L"
-        }
-        jdkVersion = 11
-        suppressGeneratedFiles = false
-        documentedVisibilities = setOf(PUBLIC)
-        perPackageOption {
-            matchingRegex = """.*\.internal.*"""
-            suppress = true
-        }
-        externalDocumentationLink("https://kotlinlang.org/api/kotlinx.coroutines/")
-        externalDocumentationLink("https://square.github.io/okhttp/4.x/okhttp/")
-        externalDocumentationLink("https://square.github.io/retrofit/2.x/retrofit/")
-        externalDocumentationLink("https://square.github.io/moshi/1.x/moshi/")
-        externalDocumentationLink("https://square.github.io/moshi/1.x/moshi-kotlin/")
-    }
-}
-
-tasks.named<Jar>("javadocJar") {
-    from(tasks.dokkaHtml)
 }

--- a/build-logic/src/main/kotlin/com/gabrielfeo/kotlin-jvm-library.gradle.kts
+++ b/build-logic/src/main/kotlin/com/gabrielfeo/kotlin-jvm-library.gradle.kts
@@ -17,8 +17,8 @@ java {
     withSourcesJar()
     withJavadocJar()
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
-        vendor.set(JvmVendorSpec.AZUL)
+        languageVersion = JavaLanguageVersion.of(11)
+        vendor = JvmVendorSpec.AZUL
     }
 }
 
@@ -27,16 +27,16 @@ tasks.withType<DokkaTask>().configureEach {
     dokkaSourceSets.all {
         sourceRoot(kotlinSourceRoot)
         sourceLink {
-            localDirectory.set(kotlinSourceRoot)
-            remoteUrl.set(repoUrl.map { URL("$it/blob/$version/${kotlinSourceRoot.relativeTo(rootDir)}") })
-            remoteLineSuffix.set("#L")
+            localDirectory = kotlinSourceRoot
+            remoteUrl = repoUrl.map { URL("$it/blob/$version/${kotlinSourceRoot.relativeTo(rootDir)}") }
+            remoteLineSuffix = "#L"
         }
-        jdkVersion.set(11)
-        suppressGeneratedFiles.set(false)
-        documentedVisibilities.set(setOf(PUBLIC))
+        jdkVersion = 11
+        suppressGeneratedFiles = false
+        documentedVisibilities = setOf(PUBLIC)
         perPackageOption {
-            matchingRegex.set(""".*\.internal.*""")
-            suppress.set(true)
+            matchingRegex = """.*\.internal.*"""
+            suppress = true
         }
         externalDocumentationLink("https://kotlinlang.org/api/kotlinx.coroutines/")
         externalDocumentationLink("https://square.github.io/okhttp/4.x/okhttp/")

--- a/build-logic/src/main/kotlin/com/gabrielfeo/kotlin-jvm-library.gradle.kts
+++ b/build-logic/src/main/kotlin/com/gabrielfeo/kotlin-jvm-library.gradle.kts
@@ -20,6 +20,9 @@ java {
         languageVersion = JavaLanguageVersion.of(11)
         vendor = JvmVendorSpec.AZUL
     }
+    consistentResolution {
+        useRuntimeClasspathVersions()
+    }
 }
 
 val kotlinSourceRoot = file("src/main/kotlin")

--- a/build-logic/src/main/kotlin/com/gabrielfeo/published-kotlin-jvm-library.gradle.kts
+++ b/build-logic/src/main/kotlin/com/gabrielfeo/published-kotlin-jvm-library.gradle.kts
@@ -1,7 +1,9 @@
 plugins {
+    id("com.gabrielfeo.kotlin-jvm-library")
     `java-library`
     `maven-publish`
     signing
+    id("org.jetbrains.kotlinx.binary-compatibility-validator")
 }
 
 publishing {

--- a/build-logic/src/main/kotlin/com/gabrielfeo/published-kotlin-jvm-library.gradle.kts
+++ b/build-logic/src/main/kotlin/com/gabrielfeo/published-kotlin-jvm-library.gradle.kts
@@ -1,9 +1,50 @@
+package com.gabrielfeo
+
+import org.jetbrains.dokka.DokkaConfiguration.Visibility.PUBLIC
+import org.jetbrains.dokka.gradle.DokkaTask
+import java.net.URL
+
 plugins {
     id("com.gabrielfeo.kotlin-jvm-library")
     `java-library`
     `maven-publish`
     signing
     id("org.jetbrains.kotlinx.binary-compatibility-validator")
+    id("org.jetbrains.dokka")
+}
+
+java {
+    withSourcesJar()
+    withJavadocJar()
+}
+
+val kotlinSourceRoot = file("src/main/kotlin")
+tasks.withType<DokkaTask>().configureEach {
+    dokkaSourceSets.all {
+        sourceRoot(kotlinSourceRoot)
+        sourceLink {
+            localDirectory = kotlinSourceRoot
+            remoteUrl = providers.gradleProperty("repo.url")
+                .map { URL("$it/blob/$version/${kotlinSourceRoot.relativeTo(rootDir)}") }
+            remoteLineSuffix = "#L"
+        }
+        jdkVersion = java.toolchain.version
+        suppressGeneratedFiles = false
+        documentedVisibilities = setOf(PUBLIC)
+        perPackageOption {
+            matchingRegex = """.*\.internal.*"""
+            suppress = true
+        }
+        externalDocumentationLink("https://kotlinlang.org/api/kotlinx.coroutines/")
+        externalDocumentationLink("https://square.github.io/okhttp/4.x/okhttp/")
+        externalDocumentationLink("https://square.github.io/retrofit/2.x/retrofit/")
+        externalDocumentationLink("https://square.github.io/moshi/1.x/moshi/")
+        externalDocumentationLink("https://square.github.io/moshi/1.x/moshi-kotlin/")
+    }
+}
+
+tasks.named<Jar>("javadocJar") {
+    from(tasks.dokkaHtml)
 }
 
 publishing {

--- a/build-logic/src/main/kotlin/com/gabrielfeo/published-kotlin-jvm-library.gradle.kts
+++ b/build-logic/src/main/kotlin/com/gabrielfeo/published-kotlin-jvm-library.gradle.kts
@@ -36,7 +36,7 @@ tasks.withType<DokkaTask>().configureEach {
             suppress = true
         }
         externalDocumentationLink("https://kotlinlang.org/api/kotlinx.coroutines/")
-        externalDocumentationLink("https://square.github.io/okhttp/4.x/okhttp/")
+        externalDocumentationLink("https://square.github.io/okhttp/5.x/okhttp/")
         externalDocumentationLink("https://square.github.io/retrofit/2.x/retrofit/")
         externalDocumentationLink("https://square.github.io/moshi/1.x/moshi/")
         externalDocumentationLink("https://square.github.io/moshi/1.x/moshi-kotlin/")

--- a/build-logic/src/main/kotlin/com/gabrielfeo/published-kotlin-jvm-library.gradle.kts
+++ b/build-logic/src/main/kotlin/com/gabrielfeo/published-kotlin-jvm-library.gradle.kts
@@ -28,7 +28,7 @@ tasks.withType<DokkaTask>().configureEach {
                 .map { URL("$it/blob/$version/${kotlinSourceRoot.relativeTo(rootDir)}") }
             remoteLineSuffix = "#L"
         }
-        jdkVersion = java.toolchain.version
+        jdkVersion = java.toolchain.languageVersion.map { it.asInt() }
         suppressGeneratedFiles = false
         documentedVisibilities = setOf(PUBLIC)
         perPackageOption {

--- a/build-logic/src/main/kotlin/com/gabrielfeo/publishing.gradle.kts
+++ b/build-logic/src/main/kotlin/com/gabrielfeo/publishing.gradle.kts
@@ -1,0 +1,39 @@
+plugins {
+    `java-library`
+    `maven-publish`
+    signing
+}
+
+publishing {
+    repositories {
+        maven {
+            name = "mavenCentral"
+            val releasesRepoUrl = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
+            val snapshotsRepoUrl = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+            val isSnapshot = version.toString().endsWith("SNAPSHOT")
+            url = if (isSnapshot) snapshotsRepoUrl else releasesRepoUrl
+            authentication {
+                register<BasicAuthentication>("basic")
+            }
+            credentials {
+                username = project.properties["maven.central.username"] as String?
+                password = project.properties["maven.central.password"] as String?
+            }
+        }
+    }
+}
+
+fun isCI() = System.getenv("CI").toBoolean()
+
+signing {
+    val signedPublications = publishing.publications.matching {
+        !it.name.contains("unsigned", ignoreCase = true)
+    }
+    sign(signedPublications)
+    if (isCI()) {
+        useInMemoryPgpKeys(
+            project.properties["signing.secretKey"] as String?,
+            project.properties["signing.password"] as String?,
+        )
+    }
+}

--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -5,10 +5,13 @@ plugins {
 }
 
 // Cross-configure so we don't pollute the example buildscript
-project("example-project").configurations.configureEach {
-    resolutionStrategy.dependencySubstitution {
-        substitute(module("com.gabrielfeo:develocity-api-kotlin"))
-            .using(project(":library"))
+project("example-project") {
+    apply(plugin = "com.gabrielfeo.kotlin-jvm-library")
+    configurations.configureEach {
+        resolutionStrategy.dependencySubstitution {
+            substitute(module("com.gabrielfeo:develocity-api-kotlin"))
+                .using(project(":library"))
+        }
     }
 }
 

--- a/examples/example-project/build.gradle.kts
+++ b/examples/example-project/build.gradle.kts
@@ -5,12 +5,12 @@ plugins {
 }
 
 application {
-    mainClass.set("com.gabrielfeo.develocity.api.example.MainKt")
+    mainClass = "com.gabrielfeo.develocity.api.example.MainKt"
 }
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
+        languageVersion = JavaLanguageVersion.of(11)
     }
 }
 

--- a/examples/example-project/build.gradle.kts
+++ b/examples/example-project/build.gradle.kts
@@ -1,17 +1,10 @@
 plugins {
-    // in your project, replace for id("org.jetbrains.kotlin.jvm")
-    id("com.gabrielfeo.kotlin-jvm-library")
+    id("org.jetbrains.kotlin.jvm")
     application
 }
 
 application {
     mainClass = "com.gabrielfeo.develocity.api.example.MainKt"
-}
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(11)
-    }
 }
 
 dependencies {

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -1,7 +1,3 @@
-@file:Suppress("UnstableApiUsage")
-
-import java.net.URL
-
 plugins {
     id("com.gabrielfeo.published-kotlin-jvm-library")
     id("com.gabrielfeo.develocity-api-code-generation")

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -52,29 +52,29 @@ dependencies {
 }
 
 val libraryPom = Action<MavenPom> {
-    name.set("Develocity API Kotlin")
-    description.set("A library to use the Develocity API in Kotlin")
+    name = "Develocity API Kotlin"
+    description = "A library to use the Develocity API in Kotlin"
     val repoUrl = providers.gradleProperty("repo.url")
-    url.set(repoUrl)
+    url = repoUrl
     licenses {
         license {
-            name.set("MIT")
-            url.set("https://spdx.org/licenses/MIT.html")
-            distribution.set("repo")
+            name = "MIT"
+            url = "https://spdx.org/licenses/MIT.html"
+            distribution = "repo"
         }
     }
     developers {
         developer {
-            id.set("gabrielfeo")
-            name.set("Gabriel Feo")
-            email.set("gabriel@gabrielfeo.com")
+            id = "gabrielfeo"
+            name = "Gabriel Feo"
+            email = "gabriel@gabrielfeo.com"
         }
     }
     scm {
         val basicUrl = repoUrl.map { it.substringAfter("://") }
-        connection.set(basicUrl.map { "scm:git:git://$it.git" })
-        developerConnection.set(basicUrl.map { "scm:git:ssh://$it.git" })
-        url.set(basicUrl.map { "https://$it/" })
+        connection = basicUrl.map { "scm:git:git://$it.git" }
+        developerConnection = basicUrl.map { "scm:git:ssh://$it.git" }
+        url = basicUrl.map { "https://$it/" }
     }
 }
 

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -3,10 +3,9 @@
 import java.net.URL
 
 plugins {
-    id("com.gabrielfeo.kotlin-jvm-library")
+    id("com.gabrielfeo.published-kotlin-jvm-library")
     id("com.gabrielfeo.develocity-api-code-generation")
     id("com.gabrielfeo.test-suites")
-    id("com.gabrielfeo.publishing")
     alias(libs.plugins.kotlin.jupyter)
 }
 

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -6,9 +6,7 @@ plugins {
     id("com.gabrielfeo.kotlin-jvm-library")
     id("com.gabrielfeo.develocity-api-code-generation")
     id("com.gabrielfeo.test-suites")
-    `java-library`
-    `maven-publish`
-    signing
+    id("com.gabrielfeo.publishing")
     alias(libs.plugins.kotlin.jupyter)
 }
 
@@ -20,12 +18,6 @@ tasks.processJupyterApiResources {
 
 tasks.named<Test>("integrationTest") {
     environment("DEVELOCITY_API_LOG_LEVEL", "DEBUG")
-}
-
-java {
-    consistentResolution {
-        useRuntimeClasspathVersions()
-    }
 }
 
 dependencies {
@@ -104,36 +96,5 @@ publishing {
                 }
             }
         }
-    }
-    repositories {
-        maven {
-            name = "mavenCentral"
-            val releasesRepoUrl = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
-            val snapshotsRepoUrl = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
-            val isSnapshot = version.toString().endsWith("SNAPSHOT")
-            url = if (isSnapshot) snapshotsRepoUrl else releasesRepoUrl
-            authentication {
-                register<BasicAuthentication>("basic")
-            }
-            credentials {
-                username = project.properties["maven.central.username"] as String?
-                password = project.properties["maven.central.password"] as String?
-            }
-        }
-    }
-}
-
-fun isCI() = System.getenv("CI").toBoolean()
-
-signing {
-    val signedPublications = publishing.publications.matching {
-        !it.name.contains("unsigned", ignoreCase = true)
-    }
-    sign(signedPublications)
-    if (isCI()) {
-        useInMemoryPgpKeys(
-            project.properties["signing.secretKey"] as String?,
-            project.properties["signing.password"] as String?,
-        )
     }
 }


### PR DESCRIPTION
- Move specific logic, such as applying a convention plugin, out of the example buildscript
- Move some publishing, dokka and binary compatibility validator setup to a new "published library" conventions plugin. This simplifies the `:library` buildscript and removes unused configuration from `:examples:example-project`
- Use new Kotlin DSL property set syntax

Tested with a `check` build: https://scans.gradle.com/s/q34f6ap23bgf2