### PR TITLE
Fix queries in examples

### DIFF
--- a/examples/example-notebooks/MostFrequentBuilds.ipynb
+++ b/examples/example-notebooks/MostFrequentBuilds.ipynb
@@ -114,7 +114,7 @@
     "val builds: List<GradleAttributes> = runBlocking {\n",
     "    api.buildsApi.getBuildsFlow(\n",
     "        fromInstant = 0,\n",
-    "        query = \"\"\"buildStartTime<-7d tag:local buildOutcome:failed\"\"\",\n",
+    "        query = \"\"\"buildStartTime>-7d tag:local\"\"\",\n",
     "        models = listOf(BuildModelName.gradleAttributes),\n",
     "    ).map {\n",
     "        it.models!!.gradleAttributes!!.model!!\n",

--- a/examples/example-project/src/main/kotlin/com/gabrielfeo/develocity/api/example/analysis/MostFrequentBuilds.kt
+++ b/examples/example-project/src/main/kotlin/com/gabrielfeo/develocity/api/example/analysis/MostFrequentBuilds.kt
@@ -27,7 +27,7 @@ suspend fun mostFrequentBuilds(
     // Fetch builds from the API
     val builds: List<GradleAttributes> = api.getBuildsFlow(
         fromInstant = 0,
-        query = """buildStartTime<$startTime tag:local buildOutcome:failed""",
+        query = """buildStartTime>$startTime tag:local""",
         models = listOf(BuildModelName.gradleAttributes),
     ).map {
         it.models!!.gradleAttributes!!.model!!

--- a/examples/example-scripts/example-script.main.kts
+++ b/examples/example-scripts/example-script.main.kts
@@ -38,7 +38,7 @@ val api = DevelocityApi.newInstance()
 val builds: List<GradleAttributes> = runBlocking {
     api.buildsApi.getBuildsFlow(
         fromInstant = 0,
-        query = """buildStartTime<-7d tag:local buildOutcome:failed""",
+        query = """buildStartTime>-7d tag:local""",
         models = listOf(BuildModelName.gradleAttributes),
     ).map {
         it.models!!.gradleAttributes!!.model!!


### PR DESCRIPTION
- The `buildStartTime` operator was inverted, causing the examples run time to be much longer than expected when API cache is off
- `buildOutcome:failed` shouldn't be in the examples, since they're supposed to present all builds