### PR TITLE
Improve examples testing

### DIFF
--- a/examples/example-notebooks/MostFrequentBuilds.ipynb
+++ b/examples/example-notebooks/MostFrequentBuilds.ipynb
@@ -121,7 +121,8 @@
     "    }.toList(LinkedList())\n",
     "}\n",
     "\n",
-    "println(\"${builds.size} builds\")"
+    "println(\"${builds.size} builds\")\n",
+    "check(builds.isNotEmpty()) { \"No builds found. Adjust query and try again.\" }"
    ]
   },
   {

--- a/examples/example-notebooks/MostFrequentBuilds.ipynb
+++ b/examples/example-notebooks/MostFrequentBuilds.ipynb
@@ -114,7 +114,7 @@
     "val builds: List<GradleAttributes> = runBlocking {\n",
     "    api.buildsApi.getBuildsFlow(\n",
     "        fromInstant = 0,\n",
-    "        query = \"\"\"buildStartTime>-7d tag:local\"\"\",\n",
+    "        query = \"\"\"buildStartTime>-7d\"\"\",\n",
     "        models = listOf(BuildModelName.gradleAttributes),\n",
     "    ).map {\n",
     "        it.models!!.gradleAttributes!!.model!!\n",

--- a/examples/example-project/src/main/kotlin/com/gabrielfeo/develocity/api/example/analysis/MostFrequentBuilds.kt
+++ b/examples/example-project/src/main/kotlin/com/gabrielfeo/develocity/api/example/analysis/MostFrequentBuilds.kt
@@ -27,7 +27,7 @@ suspend fun mostFrequentBuilds(
     // Fetch builds from the API
     val builds: List<GradleAttributes> = api.getBuildsFlow(
         fromInstant = 0,
-        query = """buildStartTime>$startTime tag:local""",
+        query = """buildStartTime>$startTime""",
         models = listOf(BuildModelName.gradleAttributes),
     ).map {
         it.models!!.gradleAttributes!!.model!!

--- a/examples/example-project/src/main/kotlin/com/gabrielfeo/develocity/api/example/analysis/MostFrequentBuilds.kt
+++ b/examples/example-project/src/main/kotlin/com/gabrielfeo/develocity/api/example/analysis/MostFrequentBuilds.kt
@@ -34,6 +34,7 @@ suspend fun mostFrequentBuilds(
     }.toList(LinkedList())
 
     // Process builds and count how many times each was invoked
+    check(builds.isNotEmpty()) { "No builds found. Adjust query and try again." }
     val buildCounts = builds.groupBy { build ->
         val tasks = build.requestedTasks.joinToString(" ").trim(':')
         tasks.ifBlank { "IDE sync" }

--- a/examples/example-scripts/example-script.main.kts
+++ b/examples/example-scripts/example-script.main.kts
@@ -46,6 +46,7 @@ val builds: List<GradleAttributes> = runBlocking {
 }
 
 // Process builds and count how many times each was invoked
+check(builds.isNotEmpty()) { "No builds found. Adjust query and try again." }
 val buildCounts = builds.groupBy { build ->
     val tasks = build.requestedTasks.joinToString(" ").trim(':')
     tasks.ifBlank { "IDE sync" }

--- a/examples/example-scripts/example-script.main.kts
+++ b/examples/example-scripts/example-script.main.kts
@@ -38,7 +38,7 @@ val api = DevelocityApi.newInstance()
 val builds: List<GradleAttributes> = runBlocking {
     api.buildsApi.getBuildsFlow(
         fromInstant = 0,
-        query = """buildStartTime>-7d tag:local""",
+        query = """buildStartTime>-7d""",
         models = listOf(BuildModelName.gradleAttributes),
     ).map {
         it.models!!.gradleAttributes!!.model!!

--- a/library/src/integrationTest/kotlin/com/gabrielfeo/develocity/api/DevelocityApiIntegrationTest.kt
+++ b/library/src/integrationTest/kotlin/com/gabrielfeo/develocity/api/DevelocityApiIntegrationTest.kt
@@ -23,7 +23,7 @@ class DevelocityApiIntegrationTest {
         val builds = api.buildsApi.getBuilds(
             since = 0,
             maxBuilds = 5,
-            query = """tag:local value:"Email=gabriel.feo*""""
+            query = """buildStartTime>-7d""""
         )
         assertEquals(5, builds.size)
         api.shutdown()


### PR DESCRIPTION
- Simplify queries to make it easier to test against fresh instances, e.g. with no builds tagged for `tag:local`.
- Ensure examples fail if 0 builds. Before, script and project examples would skip code such as `List.map` logic, hiding potential issues when testing. The notebook example would fail later in the plotting step with a non-obvious message:

```
java.lang.IllegalStateException: Column 'count' not found among [tasks].
```

