### PR TITLE
Fix Renovate schedule

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,7 +5,7 @@
   ],
   "schedule": [
     // Runs once, despite '*' minutes (https://docs.renovatebot.com/configuration-options/#schedule)
-    "* 6 * * 1",
+    "* 0-6 * * 1",
   ],
   "ignorePaths": [
     "**/test_resources/**",


### PR DESCRIPTION
This schedule is not how often Renovate should run, but rather the time window in which Renovate is allowed to create branches. [Docs recommend setting a larger time window, depending on when the used instance is set to run][1]. Increase the window, as it's not documented how often Renovate for GitHub (Mend-hosted instance) runs.

[1]: https://docs.renovatebot.com/configuration-options/#schedule