### PR TITLE
Dump new API automatically in update-api-spec

### DIFF
--- a/.github/scripts/update_api_spec_version.py
+++ b/.github/scripts/update_api_spec_version.py
@@ -11,6 +11,7 @@ LATEST_VERSION_REGEX = r'<a [^>]*href="ref/develocity-([\d.]+)-api\.yaml">Specif
 
 def main(properties_file='gradle.properties'):
     current = get_current_api_spec_version(properties_file)
+    print(f"Current spec version in", properties_file, "is", current, file=sys.stderr)
     latest = extract_latest_version()
     if current == latest:
         exit(1)
@@ -33,7 +34,9 @@ def extract_latest_version():
     resp.raise_for_status()
     match = re.search(LATEST_VERSION_REGEX, resp.text)
     if not match:
-        raise RuntimeError("Failed to retrieve latest version")
+        raise RuntimeError(f"Failed to get latest version from {VERSIONS_URL} \
+                             with /{LATEST_VERSION_REGEX}/")
+    print("First match in HTML of ", VERSIONS_URL, "is", match, file=sys.stderr)
     return match.group(1)
 
 

--- a/.github/workflows/update-api-spec.yml
+++ b/.github/workflows/update-api-spec.yml
@@ -33,6 +33,11 @@ jobs:
             echo "NEW_VERSION=$(cat new.txt)" >> $GITHUB_ENV
           fi
           rm new.txt || true
+      - name: gradle :library:apiDump
+        uses: ./.github/actions/build
+        with:
+          dry-run: ${{ inputs.dry_run }}
+          args: :library:apiDump
       - name: Check for existing PR
         if: ${{ env.NEW_VERSION }}
         run: |

--- a/.github/workflows/update-api-spec.yml
+++ b/.github/workflows/update-api-spec.yml
@@ -53,7 +53,12 @@ jobs:
         with:
           branch: "${{ env.UPDATE_BRANCH }}"
           commit-message: "Bump Develocity API spec version to ${{ env.NEW_VERSION }}"
-          title: "Bump Develocity API spec version to ${{ env.NEW_VERSION }}"
+          title: |
+            Bump Develocity API spec version to ${{ env.NEW_VERSION }}
+
+            Generated from workflow run [${{ github.run_id }}][1].
+
+            [1]: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           body: "https://docs.gradle.com/enterprise/api-manual/#release_history"
           author: "github-actions <github-actions@github.com>"
           committer: "github-actions <github-actions@github.com>"


### PR DESCRIPTION
Dump the new library API as part of the update-api-spec workflow, including it in the spec update PR.

Also improve the update script with some logging and add a link in the PR to the job that created/modified it.