### PR TITLE
Shorten Renovate commit subjects

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -17,6 +17,8 @@
   "rebaseWhen": "behind-base-branch",
   // Remove configDescription from PR body
   "prBodyTemplate": "{{{header}}}{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}{{{controls}}}{{{footer}}}",
+  // Remove "dependency " prefix which makes message subjects too long
+  "commitMessageTopic": "{{depName}}",
   "packageRules": [
     // Add a changelog link to Develocity plugin PRs
     {


### PR DESCRIPTION
By removing the "dependency " prefix, e.g. "Update dependency retrofit to v2.12.0"