### PR TITLE
Run integration tests and examples in CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,12 +20,7 @@ jobs:
       - name: gradle test
         uses: ./.github/actions/build
         with:
-          args: >-
-            test
-            compileIntegrationTestKotlin
-            compileExamplesTestKotlin
-            :build-logic:check
-            :library:apiCheck
+          args: check
 
   python-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: gradle test
+      - name: gradle check
         uses: ./.github/actions/build
         with:
           args: check

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ jobs:
   kotlin-tests:
     runs-on: ubuntu-latest
     env:
-      DEVELOCITY_API_URL: "${{ variables.DEVELOCITY_API_URL }}"
+      DEVELOCITY_API_URL: "${{ vars.DEVELOCITY_API_URL }}"
       DEVELOCITY_API_TOKEN: "${{ secrets.DEVELOCITY_API_TOKEN }}"
     steps:
       - name: Checkout

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,6 +11,9 @@ jobs:
 
   kotlin-tests:
     runs-on: ubuntu-latest
+    env:
+      DEVELOCITY_API_URL: "${{ variables.DEVELOCITY_API_URL }}"
+      DEVELOCITY_API_TOKEN: "${{ secrets.DEVELOCITY_API_TOKEN }}"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/publish-library.yml
+++ b/.github/workflows/publish-library.yml
@@ -25,7 +25,7 @@ jobs:
   build-and-publish:
     runs-on: ubuntu-latest
     env:
-      DEVELOCITY_API_URL: "${{ variables.DEVELOCITY_API_URL }}"
+      DEVELOCITY_API_URL: "${{ vars.DEVELOCITY_API_URL }}"
       DEVELOCITY_API_TOKEN: "${{ secrets.DEVELOCITY_API_TOKEN }}"
     steps:
       - name: Checkout

--- a/.github/workflows/publish-library.yml
+++ b/.github/workflows/publish-library.yml
@@ -24,6 +24,9 @@ jobs:
 
   build-and-publish:
     runs-on: ubuntu-latest
+    env:
+      DEVELOCITY_API_URL: "${{ variables.DEVELOCITY_API_URL }}"
+      DEVELOCITY_API_TOKEN: "${{ secrets.DEVELOCITY_API_TOKEN }}"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -35,6 +38,7 @@ jobs:
         with:
           dry-run: ${{ inputs.dry_run }}
           args: >-
+            check
             publishDevelocityApiKotlinPublicationToMavenCentralRepository
             publishRelocationPublicationToMavenCentralRepository
             --rerun-tasks

--- a/build-logic/src/main/kotlin/com/gabrielfeo/kotlin-jvm-library.gradle.kts
+++ b/build-logic/src/main/kotlin/com/gabrielfeo/kotlin-jvm-library.gradle.kts
@@ -24,3 +24,11 @@ testing {
         }
     }
 }
+
+val testTasks = tasks.named {
+    it == "check" || it.contains("test", ignoreCase = true)
+}
+
+tasks.named { it.startsWith("publish") }.configureEach {
+    mustRunAfter(testTasks)
+}

--- a/build-logic/src/main/kotlin/com/gabrielfeo/kotlin-jvm-library.gradle.kts
+++ b/build-logic/src/main/kotlin/com/gabrielfeo/kotlin-jvm-library.gradle.kts
@@ -30,5 +30,5 @@ val testTasks = tasks.named {
 }
 
 tasks.named { it.startsWith("publish") }.configureEach {
-    mustRunAfter(testTasks)
+    shouldRunAfter(testTasks)
 }

--- a/library/src/examplesTest/kotlin/com/gabrielfeo/develocity/api/example/notebook/NotebooksTest.kt
+++ b/library/src/examplesTest/kotlin/com/gabrielfeo/develocity/api/example/notebook/NotebooksTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import kotlin.io.path.Path
 import kotlin.io.path.absolute
@@ -13,6 +14,7 @@ import kotlin.io.path.div
 
 class NotebooksTest {
 
+    @TempDir
     lateinit var tempDir: Path
 
     lateinit var venv: PythonVenv


### PR DESCRIPTION
Run `integrationTest` and `examplesTest` test suites in CI as part of PR checks and before publishing artifacts, as a final validation. 

#432 and this PR are aimed at preventing regressions such as #426.

These test suites require a real Develocity server to make API requests to. This was previously not possible because the maintainer didn't have access to a Develocity server that could be used from a public GitHub repository's workflows. As a result, the `integrationTest` suite and the examples had to be manually ran locally against the Develocity server that was available. That was always done for significant PRs and before each release. Now, with access to a server that can be used in this repository, changes can be fully validated in CI, reducing the effort needed to make changes to the library.

Also fix the `examplesTest` notebooks test which broke from the `@TempDir` annotation being accidentally removed in 309acfe87f4b2381d32576eef3e5a4b39c7b44d8. Since it was a trivial change, tests were not ran locally. After this PR, a commit such as this being merged will no longer be possible.