### PR TITLE
Fix publish-javadoc workflow

### DIFF
--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -50,6 +50,8 @@ jobs:
         run: rm -rf docs
       - name: Download new javadoc
         uses: actions/download-artifact@v5
+        with:
+          path: docs
       - name: Commit
         run: |
           git config user.name github-actions

--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -50,8 +50,6 @@ jobs:
         run: rm -rf docs
       - name: Download new javadoc
         uses: actions/download-artifact@v5
-        with:
-          path: ./
       - name: Commit
         run: |
           git config user.name github-actions


### PR DESCRIPTION
Fix GH pages publishing workflow error, since #445. Was not caught by dry-run workflow that runs in PRs because the dry-run is sensitive to the current `gh-pages` branch contents. A 1st workflow run pushed an empty commit, then the [2nd run][1] failed.

[1]: https://github.com/gabrielfeo/develocity-api-kotlin/actions/runs/17628318940