### PR TITLE
Cache pip packages in CI

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -24,6 +24,11 @@ runs:
         java-version: |
           24
           17
+    - name: Setup Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.13'
+        cache: 'pip'
     - name: Set up Gradle
       uses: gradle/actions/setup-gradle@v4
       with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,6 +28,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+          cache: 'pip'
       - run: pip install -r .github/scripts/requirements.txt
       - name: 'unittest discover'
         run: python3 -m unittest discover -bs .github/scripts

--- a/.github/workflows/update-examples.yml
+++ b/.github/workflows/update-examples.yml
@@ -27,6 +27,11 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+          cache: 'pip'
       - run: pip install -r .github/scripts/requirements.txt
       - name: 'Get versions'
         run: |

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -129,13 +129,12 @@ tasks.named<Test>("test") {
 
 tasks.named<Test>("integrationTest") {
     environment = emptyMap()
-    maxParallelForks = 6
 }
 
 val publishUnsignedSnapshotDevelocityApiKotlinPublicationToMavenLocal by tasks.getting
 
 tasks.named<Test>("examplesTest") {
-    maxParallelForks = 2
+    maxParallelForks = 4
     inputs.files(files(publishUnsignedSnapshotDevelocityApiKotlinPublicationToMavenLocal))
         .withPropertyName("snapshotPublicationArtifacts")
         .withNormalizer(ClasspathNormalizer::class)

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -116,11 +116,12 @@ tasks.named("compileKotlin", KotlinCompile::class) {
 }
 
 tasks.withType<Test>().configureEach {
-    maxParallelForks = 4
-    systemProperty(
-        "junit.jupiter.tempdir.cleanup.mode.default",
-        System.getProperty("junit.jupiter.tempdir.cleanup.mode.default") ?: "always",
-    )
+    maxParallelForks = 6
+    systemProperty("junit.jupiter.execution.parallel.enabled", "true")
+    systemProperty("junit.jupiter.execution.parallel.mode.default", "same_thread")
+    val cleanupMode = System.getProperty("junit.jupiter.tempdir.cleanup.mode.default")
+        ?: "always"
+    systemProperty("junit.jupiter.tempdir.cleanup.mode.default", cleanupMode)
 }
 
 tasks.named<Test>("test") {

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -138,6 +138,7 @@ tasks.named<Test>("examplesTest") {
     inputs.files(files(publishUnsignedSnapshotDevelocityApiKotlinPublicationToMavenLocal))
         .withPropertyName("snapshotPublicationArtifacts")
         .withNormalizer(ClasspathNormalizer::class)
+    environment("DEVELOCITY_API_CACHE_ENABLED", "false")
     providers.environmentVariablesPrefixedBy("DEVELOCITY_API_").get().forEach { (name, value) ->
         inputs.property("${name}.hashCode", value.hashCode())
     }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -116,7 +116,6 @@ tasks.named("compileKotlin", KotlinCompile::class) {
 }
 
 tasks.withType<Test>().configureEach {
-    maxParallelForks = 6
     systemProperty("junit.jupiter.execution.parallel.enabled", "true")
     systemProperty("junit.jupiter.execution.parallel.mode.default", "same_thread")
     val cleanupMode = System.getProperty("junit.jupiter.tempdir.cleanup.mode.default")
@@ -130,11 +129,13 @@ tasks.named<Test>("test") {
 
 tasks.named<Test>("integrationTest") {
     environment = emptyMap()
+    maxParallelForks = 6
 }
 
 val publishUnsignedSnapshotDevelocityApiKotlinPublicationToMavenLocal by tasks.getting
 
 tasks.named<Test>("examplesTest") {
+    maxParallelForks = 2
     inputs.files(files(publishUnsignedSnapshotDevelocityApiKotlinPublicationToMavenLocal))
         .withPropertyName("snapshotPublicationArtifacts")
         .withNormalizer(ClasspathNormalizer::class)

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -128,6 +128,7 @@ tasks.named<Test>("test") {
 }
 
 tasks.named<Test>("integrationTest") {
+    maxParallelForks = 2
     environment = emptyMap()
 }
 

--- a/library/src/examplesTest/kotlin/com/gabrielfeo/develocity/api/example/gradle/ExampleGradleTaskTest.kt
+++ b/library/src/examplesTest/kotlin/com/gabrielfeo/develocity/api/example/gradle/ExampleGradleTaskTest.kt
@@ -2,7 +2,6 @@ package com.gabrielfeo.develocity.api.example.gradle
 
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.TestMethodOrder
@@ -12,27 +11,22 @@ import java.nio.file.Path
 import com.gabrielfeo.develocity.api.copyFromResources
 import com.gabrielfeo.develocity.api.example.BuildStartTime
 import com.gabrielfeo.develocity.api.example.runInShell
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT
 import kotlin.io.path.div
 
 @TestMethodOrder(OrderAnnotation::class)
+@Execution(CONCURRENT)
 class ExampleGradleTaskTest {
 
-    @TempDir
-    lateinit var tempDir: Path
-
-    private val projectDir
-        get() = tempDir / "examples/example-gradle-task"
-
-    @BeforeEach
-    fun setup() {
-        copyFromResources("/examples", tempDir)
-        copyFromResources("/${ResourceInitScripts.FORCE_SNAPSHOT_LIBRARY}", tempDir)
-        copyFromResources("/${ResourceInitScripts.REQUIRE_JAVA_11_COMPATIBILITY}", tempDir)
+    class TestPaths(val rootDir: Path) {
+        val initScriptsDir = rootDir
+        val projectDir = rootDir / "examples/example-gradle-task"
     }
 
     @Test
     @Order(1)
-    fun smokeTest() {
+    fun smokeTest(@TempDir tempDir: Path) = with(setup(tempDir)) {
         val dependencies = runBuild(":buildSrc:dependencies --configuration runtimeClasspath").stdout
         val libraryMatches = dependencies.lines().filter { "develocity-api-kotlin" in it }
         assertTrue(libraryMatches.isNotEmpty())
@@ -41,25 +35,32 @@ class ExampleGradleTaskTest {
         }
     }
 
+    private fun setup(tempDir: Path): TestPaths {
+        copyFromResources("/examples", tempDir)
+        copyFromResources("/${ResourceInitScripts.FORCE_SNAPSHOT_LIBRARY}", tempDir)
+        copyFromResources("/${ResourceInitScripts.REQUIRE_JAVA_11_COMPATIBILITY}", tempDir)
+        return TestPaths(tempDir)
+    }
+
     @Test
-    fun testBuildPerformanceMetricsTask() {
+    fun testBuildPerformanceMetricsTask(@TempDir tempDir: Path) = with(setup(tempDir)) {
         val args = "--user runner --period=${BuildStartTime.RECENT}"
         val output = runBuild("userBuildPerformanceMetrics $args").stdout
         assertPerformanceMetricsOutput(output, user = "runner", period = BuildStartTime.RECENT)
     }
 
     @Test
-    fun testJavaVersionCompatibility() {
-        val initScript = tempDir / ResourceInitScripts.REQUIRE_JAVA_11_COMPATIBILITY
+    fun testJavaVersionCompatibility(@TempDir tempDir: Path) = with(setup(tempDir)) {
+        val initScript = initScriptsDir / ResourceInitScripts.REQUIRE_JAVA_11_COMPATIBILITY
         val output = runBuild("-p buildSrc :generateExternalPluginSpecBuilders -I '$initScript'").stdout
         assertFalse(Regex("""FAILED|Could not resolve|No matching variant""").containsMatchIn(output))
     }
 
-    private fun runBuild(gradleArgs: String) =
+    private fun TestPaths.runBuild(gradleArgs: String) =
         runInShell(
             projectDir,
             "./gradlew --stacktrace --no-daemon",
-            "-I ${tempDir / ResourceInitScripts.FORCE_SNAPSHOT_LIBRARY}",
+            "-I ${initScriptsDir / ResourceInitScripts.FORCE_SNAPSHOT_LIBRARY}",
             gradleArgs,
         )
 

--- a/library/src/examplesTest/kotlin/com/gabrielfeo/develocity/api/example/gradle/ExampleGradleTaskTest.kt
+++ b/library/src/examplesTest/kotlin/com/gabrielfeo/develocity/api/example/gradle/ExampleGradleTaskTest.kt
@@ -2,9 +2,6 @@ package com.gabrielfeo.develocity.api.example.gradle
 
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.MethodOrderer.OrderAnnotation
-import org.junit.jupiter.api.Order
-import org.junit.jupiter.api.TestMethodOrder
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
@@ -15,7 +12,6 @@ import org.junit.jupiter.api.parallel.Execution
 import org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT
 import kotlin.io.path.div
 
-@TestMethodOrder(OrderAnnotation::class)
 @Execution(CONCURRENT)
 class ExampleGradleTaskTest {
 
@@ -25,8 +21,7 @@ class ExampleGradleTaskTest {
     }
 
     @Test
-    @Order(1)
-    fun smokeTest(@TempDir tempDir: Path) = with(setup(tempDir)) {
+    fun ensureRunBuildUsesSnapshotDependency(@TempDir tempDir: Path) = with(setup(tempDir)) {
         val dependencies = runBuild(":buildSrc:dependencies --configuration runtimeClasspath").stdout
         val libraryMatches = dependencies.lines().filter { "develocity-api-kotlin" in it }
         assertTrue(libraryMatches.isNotEmpty())
@@ -64,6 +59,7 @@ class ExampleGradleTaskTest {
             gradleArgs,
         )
 
+    @Suppress("SameParameterValue")
     private fun assertPerformanceMetricsOutput(
         output: String,
         user: String,

--- a/library/src/examplesTest/kotlin/com/gabrielfeo/develocity/api/example/notebook/NotebooksTest.kt
+++ b/library/src/examplesTest/kotlin/com/gabrielfeo/develocity/api/example/notebook/NotebooksTest.kt
@@ -4,10 +4,11 @@ import com.gabrielfeo.develocity.api.copyFromResources
 import com.gabrielfeo.develocity.api.example.JsonAdapter
 import com.gabrielfeo.develocity.api.example.Queries
 import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT
 import java.net.URI
 import java.nio.file.Path
 import kotlin.io.path.Path
@@ -15,32 +16,15 @@ import kotlin.io.path.absolute
 import kotlin.io.path.div
 import kotlin.io.path.writeText
 
+@Execution(CONCURRENT)
 class NotebooksTest {
 
-    @TempDir
-    lateinit var tempDir: Path
-
-    lateinit var venv: PythonVenv
-
-    lateinit var jupyter: Jupyter
-
-    @BeforeEach
-    fun setup() {
-        copyFromResources("/examples", tempDir)
-        venv = PythonVenv(tempDir / ".venv").also {
-            it.installRequirements(
-                requirementsFile = tempDir / "examples/example-notebooks/requirements.txt",
-                linksDir = Path(System.getProperty("downloaded-requirements-path")).absolute(),
-            )
-        }
-        jupyter = Jupyter(tempDir, venv.dir)
-    }
-
     @Test
-    fun testMostFrequentBuildsNotebook() {
+    fun testMostFrequentBuildsNotebook(@TempDir tempDir: Path) {
+        val jupyter = setup(tempDir)
         val sourceNotebook = tempDir / "examples/example-notebooks/MostFrequentBuilds.ipynb"
-        val fasterNotebook = forceUseOfFasterQuery(sourceNotebook)
-        val snapshotNotebook = forceUseOfMavenLocalSnapshotArtifact(fasterNotebook)
+        val fasterNotebook = jupyter.forceUseOfFasterQuery(sourceNotebook)
+        val snapshotNotebook = jupyter.forceUseOfMavenLocalSnapshotArtifact(fasterNotebook)
         val executedNotebook = assertDoesNotThrow { jupyter.executeNotebook(snapshotNotebook) }
         with(JsonAdapter.fromJson(executedNotebook.outputNotebook).asNotebookJson()) {
             assertTrue(textOutputLines.any { Regex("""Collected \d+ builds from the API""").containsMatchIn(it) }) {
@@ -55,27 +39,39 @@ class NotebooksTest {
         }
     }
 
-    private fun forceUseOfFasterQuery(sourceNotebook: Path): Path = jupyter.replacePattern(
+    private fun setup(tempDir: Path): Jupyter {
+        copyFromResources("/examples", tempDir)
+        val venv = PythonVenv(tempDir / ".venv").also {
+            it.installRequirements(
+                requirementsFile = tempDir / "examples/example-notebooks/requirements.txt",
+                linksDir = Path(System.getProperty("downloaded-requirements-path")).absolute(),
+            )
+        }
+        return Jupyter(tempDir, venv.dir)
+    }
+
+    private fun Jupyter.forceUseOfFasterQuery(sourceNotebook: Path): Path = replacePattern(
         path = sourceNotebook,
         pattern = Regex("""query\s*=.+,"""),
         replacement = """query = "${Queries.FAST}",""",
     )
 
     @Test
-    fun testLoggingNotebook() {
+    fun testLoggingNotebook(@TempDir tempDir: Path) {
+        val jupyter = setup(tempDir)
         val sourceNotebook = tempDir / "examples/example-notebooks/Logging.ipynb"
-        val snapshotNotebook = forceUseOfMavenLocalSnapshotArtifact(sourceNotebook)
+        val snapshotNotebook = jupyter.forceUseOfMavenLocalSnapshotArtifact(sourceNotebook)
         val executedNotebook = assertDoesNotThrow { jupyter.executeNotebook(snapshotNotebook) }
         val kernelLogs = executedNotebook.outputStreams.stderr
         assertTrue(kernelLogs.contains("gabrielfeo.develocity.api.Cache - HTTP cache", ignoreCase = true))
     }
 
-    private fun forceUseOfMavenLocalSnapshotArtifact(sourceNotebook: Path): Path {
+    private fun Jupyter.forceUseOfMavenLocalSnapshotArtifact(sourceNotebook: Path): Path {
         val mavenLocal = Path(System.getProperty("user.home"), ".m2/repository").toUri()
-        val libraryDescriptor = (tempDir / "develocity-api-kotlin.json").apply {
+        val libraryDescriptor = (workDir / "develocity-api-kotlin.json").apply {
             writeText(buildLibraryDescriptor(version = "SNAPSHOT", repository = mavenLocal))
         }
-        return jupyter.replacePattern(
+        return replacePattern(
             path = sourceNotebook,
             pattern = Regex("(?:DependsOn|%use).*develocity-api-kotlin.*"),
             replacement = """
@@ -86,6 +82,7 @@ class NotebooksTest {
         )
     }
 
+    @Suppress("SameParameterValue")
     private fun buildLibraryDescriptor(version: String, repository: URI) = """
         {
           "dependencies": ["com.gabrielfeo:develocity-api-kotlin:$version"],

--- a/library/src/integrationTest/kotlin/com/gabrielfeo/develocity/api/internal/jupyter/DevelocityApiJupyterIntegrationTest.kt
+++ b/library/src/integrationTest/kotlin/com/gabrielfeo/develocity/api/internal/jupyter/DevelocityApiJupyterIntegrationTest.kt
@@ -5,12 +5,15 @@ import com.google.common.reflect.ClassPath.ClassInfo
 import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlinx.jupyter.api.Code
 import org.jetbrains.kotlinx.jupyter.testkit.JupyterReplTestCase
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT
 import kotlin.reflect.KVisibility
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 
 @ExperimentalStdlibApi
+@Execution(CONCURRENT)
 class DevelocityApiJupyterIntegrationTest : JupyterReplTestCase() {
 
     @Test

--- a/scenarios.conf
+++ b/scenarios.conf
@@ -1,7 +1,6 @@
 base = {
-    cleanup-tasks = ["cleanExamplesTest"]
-    tasks = ["examplesTest"]
-    gradle-args = ["-I", "../test-filters.init.gradle", "--no-build-cache"]
+    tasks = ["check"]
+    gradle-args = ["--rerun-tasks"]
     warm-ups = 3
     iterations = 6
 }

--- a/scenarios.conf
+++ b/scenarios.conf
@@ -1,0 +1,19 @@
+base = {
+    cleanup-tasks = ["cleanExamplesTest"]
+    tasks = ["examplesTest"]
+    gradle-args = ["-I", "../test-filters.init.gradle", "--no-build-cache"]
+    warm-ups = 3
+    iterations = 6
+}
+
+serial = ${base} {
+    git-checkout = {
+        build = ${SERIAL_REF}
+    }
+}
+
+concurrent = ${base} {
+    git-checkout = {
+        build = ${CONCURRENT_REF}
+    }
+}


### PR DESCRIPTION
downloadPipRequirements task has been taking a consistently long time in CI ephemeral environments. [Build scan][1].

[1]: https://ge.solutions-team.gradle.com/s/sdv2sq33pvvsq/timeline?sort=longest#xynsayna5w7kg