### PR TITLE
Improve caching in CI workflows

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -24,6 +24,11 @@ runs:
         java-version: |
           24
           17
+    - name: Setup Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.13'
+        cache: 'pip'
     - name: Set up Gradle
       uses: gradle/actions/setup-gradle@v4
       with:

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -34,9 +34,9 @@ runs:
       with:
         validate-wrappers: true
         add-job-summary-as-pr-comment: 'on-failure'
-        # Disable cache for releases, enable write everywhere else
-        cache-read-only: false
+        # Disable cache for releases, disable write for bot branches, enable write everywhere else
         cache-disabled: ${{ startsWith('refs/tags', github.ref) }}
+        cache-read-only: ${{ contains('renovate/', github.ref) || contains('bot/', github.ref) }}
     - name: Run Gradle
       shell: bash
       run: |

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -34,6 +34,9 @@ runs:
       with:
         validate-wrappers: true
         add-job-summary-as-pr-comment: 'on-failure'
+        # Disable cache for releases, enable write everywhere else
+        cache-read-only: false
+        cache-disabled: ${{ startsWith('refs/tags', github.ref) }}
     - name: Run Gradle
       shell: bash
       run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,6 +28,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+          cache: 'pip'
       - run: pip install -r .github/scripts/requirements.txt
       - name: 'unittest discover'
         run: python3 -m unittest discover -bs .github/scripts

--- a/.github/workflows/update-examples.yml
+++ b/.github/workflows/update-examples.yml
@@ -27,6 +27,11 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+          cache: 'pip'
       - run: pip install -r .github/scripts/requirements.txt
       - name: 'Get versions'
         run: |


### PR DESCRIPTION
- **Cache pip packages in CI** (may not be working as is since pip packages of `downloadPipRequirements` task are downloaded to a non-standard location, but still worth it for other cases and makes the Python version stable throughout workflows)
- **Enable local cache in all branches** (but disable for tag builds and keep read-only for bot PRs as a security measure; PRs from external contributors will always require approval for running so I don't consider this a significant security risk)
